### PR TITLE
fix: hide header help module

### DIFF
--- a/components/header/AccountDropdown.vue
+++ b/components/header/AccountDropdown.vue
@@ -36,7 +36,7 @@
             </template>
           </CommonButtonDropdown>
         </MenuItem>
-        <MenuItem v-slot="{ active }" as="template">
+        <!-- <MenuItem v-slot="{ active }" as="template">
           <CommonButtonDropdown
             size="sm"
             no-chevron
@@ -49,7 +49,7 @@
             </template>
             <span>Help</span>
           </CommonButtonDropdown>
-        </MenuItem>
+        </MenuItem> -->
         <MenuItem v-slot="{ active }" as="template">
           <CommonButtonDropdown
             size="sm"


### PR DESCRIPTION
Hide the help module of the header account drop-down box.